### PR TITLE
fix: specify the rust toolchain in pipeline

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -49,3 +49,4 @@ jobs:
         with:
           RUSTTARGET: ${{ matrix.target }}
           EXTRA_FILES: 'README.md LICENSE'
+          TOOLCHAIN_VERSION: stable


### PR DESCRIPTION
- .github/workflows/release-build.yaml
  - For use latest stable toolchain in building, set `TOOLCHAIN_VERSION` to `stable`.